### PR TITLE
Script to take historic png screenshots of Francine

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,2 @@
+tap "homebrew/cask"
+cask "chromedriver"

--- a/generate_screenshots
+++ b/generate_screenshots
@@ -1,0 +1,86 @@
+#!/usr/bin/env ruby
+require "bundler/inline"
+
+gemfile do
+  source 'https://rubygems.org' do
+    gem "capybara-screenshot"
+    gem "selenium-webdriver"
+  end
+end
+
+require "capybara-screenshot"
+require "selenium/webdriver"
+
+HTML_FILE = "index.html"
+CSS_FILE = "francine.css"
+SCREENSHOTS_DIR = "screenshots"
+
+def configure_capybara
+  Capybara.register_driver :selenium do |app|
+    Capybara::Selenium::Driver.new(
+      app,
+      browser: :chrome,
+      options: Selenium::WebDriver::Chrome::Options.new(
+        args: %w[headless disable-gpu window-size=722,1246],
+      )
+    )
+  end
+
+  Capybara.configure do |config|
+    config.run_server = false
+    config.default_driver = :selenium
+    config.app_host = 'file://'
+  end
+
+  Capybara::Screenshot.capybara_tmp_path = "#{Dir.pwd}/#{SCREENSHOTS_DIR}"
+  Capybara::Screenshot.append_timestamp = false
+end
+
+def create_screenshots_dir
+  `mkdir -p screenshots`
+end
+
+def all_commits
+  @all_commits ||= `git log --format=format:%H`.split("\n").reverse
+end
+
+def files_exist?(sha)
+  [HTML_FILE, CSS_FILE].each do |file|
+    `rm #{file} 2> /dev/null`
+    `git checkout #{sha} -- #{file} 2> /dev/null`
+    return false unless File.exist?(file)
+  end
+  true
+end
+
+def print_progress(current, total)
+  print "#{current}/#{total}", 13.chr;
+end
+
+def save_screenshot(file_name)
+  Capybara.current_session.visit("#{Dir.pwd}/#{HTML_FILE}")
+  saver = Capybara::Screenshot.new_saver(Capybara, Capybara.page, false, file_name)
+  saver.save
+end
+
+def reset
+  `git reset --hard HEAD`
+end
+
+if $0 == __FILE__
+  Signal.trap("SIGINT") do
+    print "stopping..."
+    reset
+    exit
+  end
+
+  configure_capybara
+  create_screenshots_dir
+  all_commits.each_with_index do |sha, index|
+    print_progress(index, all_commits.length)
+    if files_exist?(sha)
+      save_screenshot("#{index}_#{sha}")
+    end
+  end
+  reset
+end


### PR DESCRIPTION
👋 @cyanharlow 

I was curious to see the evolution of Francine over time. For that reason, I hacked (in the strict sense) a ruby script that walks the git history and takes a screenshot of Francine at that point in time. Each screenshot is saved to `screenshots/$INDEX_$SHA.png` file, where `$INDEX` is the position of the change in the history in chronological order.

![gif](https://user-images.githubusercontent.com/210307/51220711-a8a7ac00-1936-11e9-91b6-037df11c758e.gif)

Provided that you are running on a Mac with [homebrew installed](https://brew.sh/), `brew bundle && ./generate_screenshots` should be all you need to do. Note the first time the script runs, it will take a bit longer if you don't have the required dependencies installed.

These PR might or might not make sense to be merged into master, but in case you want to take a look at the script, here it is.

I ❤️your work! Thank you!